### PR TITLE
fixed outdated dependency for telnet-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-red-contrib-amcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "AMCP for querying CasparCG via telnet using the telnet-client JS library",
   "main": "amcp.js",
   "dependencies"  : {
-        "telnet-client": "^0.15.5"
+        "telnet-client": "^0.16.4"
     },
   "keywords": [ "node-red" ],
   "repository" : {


### PR DESCRIPTION
already tested in my local environment:

the current version of telnet-client will crash the entire process if the network endpoint is unreachable.

fix: changed the dependency to the lowest available that fixes the issue, to avoid compatibility issues.